### PR TITLE
Fix Unicode encoding error when writing deck paths with emoji

### DIFF
--- a/helpers/write_apkg.py
+++ b/helpers/write_apkg.py
@@ -123,4 +123,9 @@ def _write_new_apkg(deck_payloads, media_files):
     temp_path = write_package_to_temp_file(package)
     final_path = rename_temp_file(temp_path, sanitized_name, first_deck_id)
 
-    sys.stdout.write(final_path)
+    # Handle Unicode characters properly for Windows console
+    try:
+        sys.stdout.write(final_path)
+    except UnicodeEncodeError:
+        # If Unicode encoding fails, encode to bytes and write to stdout buffer
+        sys.stdout.buffer.write(final_path.encode('utf-8'))


### PR DESCRIPTION
Fixes the UnicodeEncodeError that occurs on Windows when deck names contain emoji characters.

**Problem:**
- Python script fails with  when deck names contain emoji
- This happens because Windows console uses cp1252 encoding which can't handle Unicode characters
- The error occurs in  when writing the output file path

**Solution:**
- Added try/catch block around 
- If UnicodeEncodeError occurs, fallback to writing UTF-8 encoded bytes to 
- This ensures compatibility across all platforms while preserving Unicode characters

**Testing:**
- All existing tests pass
- Verified Unicode characters in deck names work correctly
- Tested with emoji characters that were previously causing failures

Resolves conversion failures when deck names contain Unicode/emoji characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console output to reliably handle Unicode characters in file paths, preventing encoding errors on some systems. This ensures that non-English characters display correctly when paths are printed, reducing crashes and garbled text during operations involving package files.
* **Chores**
  * Enhanced cross-platform robustness of output handling for environments with limited default encoding support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->