### PR TITLE
fix: use os.replace to handle existing .apkg files on Windows

### DIFF
--- a/helpers/write_apkg.py
+++ b/helpers/write_apkg.py
@@ -124,16 +124,14 @@ def rename_temp_file(temp_path, sanitized_name, first_deck_id):
     _verify_path_within_cwd(final_path, cwd)
 
     try:
-        os.rename(temp_path, final_path)
+        os.replace(temp_path, final_path)
     except OSError as e:
         if e.errno == 36:
             fallback_filename = f"deck_{uuid.uuid4().hex[:8]}.apkg"
             final_path = os.path.join(cwd, fallback_filename)
             _verify_path_within_cwd(final_path, cwd)
-            os.rename(temp_path, final_path)
-            print(f"Warning: Filename too long. Saved as {final_path}")
+            os.replace(temp_path, final_path)
         else:
-            print(f"Error renaming file: {e}")
             raise ValueError("Failed to rename file") from e
 
     return final_path

--- a/tests/test_write_apkg.py
+++ b/tests/test_write_apkg.py
@@ -27,8 +27,8 @@ class TestWriteApkg(TestCase):
             self.assertEqual(sanitize_filename(input_name), expected)
 
     @mock.patch('helpers.write_apkg.Package')
-    @mock.patch('os.rename')
-    def test_write_new_apkg_single_deck(self, mock_rename, mock_package):
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_single_deck(self, mock_replace, mock_package):
         note = Note(model=self.test_model, fields=['Q1', 'A1'])
         deck_payload = {
             "id": 1234567890,
@@ -49,11 +49,11 @@ class TestWriteApkg(TestCase):
                 
                 # Verify file operations
                 mock_package.return_value.write_to_file.assert_called_once()
-                mock_rename.assert_called_once()
+                mock_replace.assert_called_once()
 
     @mock.patch('helpers.write_apkg.Package')
-    @mock.patch('os.rename')
-    def test_write_new_apkg_multiple_decks(self, mock_rename, mock_package):
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_multiple_decks(self, mock_replace, mock_package):
         note1 = Note(model=self.test_model, fields=['Q1', 'A1'])
         note2 = Note(model=self.test_model, fields=['Q2', 'A2'])
         
@@ -84,11 +84,11 @@ class TestWriteApkg(TestCase):
                 
                 # Verify file operations
                 mock_package.return_value.write_to_file.assert_called_once()
-                mock_rename.assert_called_once()
+                mock_replace.assert_called_once()
 
     @mock.patch('helpers.write_apkg.Package')
-    @mock.patch('os.rename')
-    def test_write_new_apkg_with_media(self, mock_rename, mock_package):
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_with_media(self, mock_replace, mock_package):
         note = Note(model=self.test_model, fields=['Q1', 'A1'])
         deck_payload = {
             "id": 1234567890,
@@ -108,21 +108,21 @@ class TestWriteApkg(TestCase):
                 
                 # Verify file operations
                 mock_package.return_value.write_to_file.assert_called_once()
-                mock_rename.assert_called_once()
+                mock_replace.assert_called_once()
 
     @mock.patch('helpers.write_apkg.Package')
-    @mock.patch('os.rename')
-    def test_write_new_apkg_empty_deck_list(self, mock_rename, mock_package):
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_empty_deck_list(self, mock_replace, mock_package):
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch('os.getcwd', return_value=tmpdir):
                 _write_new_apkg([], [])
                 
                 mock_package.assert_called_once()
                 mock_package.return_value.write_to_file.assert_called_once()
-                mock_rename.assert_called_once()
+                mock_replace.assert_called_once()
                 
                 # Verify the default name is used
-                _, dst = mock_rename.call_args[0]
+                _, dst = mock_replace.call_args[0]
                 self.assertIn("default-", dst)
 
     def test_sanitize_filename_security(self):


### PR DESCRIPTION
os.rename fails on Windows when the target file already exists (WinError 183). Switched to os.replace which atomically overwrites. Also removed a print statement that crashed with UnicodeEncodeError when Windows produced a Japanese error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved file-handling reliability during package creation to reduce failures with certain filenames, leading to fewer interruptions.
  * Removed console warning and error messages that were previously printed during file operations for cleaner runtime output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->