### PR TITLE
fix: skip missing media files instead of crashing

### DIFF
--- a/helpers/write_apkg.py
+++ b/helpers/write_apkg.py
@@ -146,7 +146,11 @@ def _write_new_apkg(deck_payloads, media_files):
     """
     decks, first_deck_id = create_decks(deck_payloads)
     package = Package(decks)
-    package.media_files = media_files
+    existing_media = [f for f in media_files if os.path.exists(f)]
+    if len(existing_media) < len(media_files):
+        missing = set(media_files) - set(existing_media)
+        print(f"Skipping {len(missing)} missing media file(s): {missing}", file=sys.stderr)
+    package.media_files = existing_media
 
     sanitized_name = sanitize_filename(deck_payloads[0]["name"]) if deck_payloads else "default"
     temp_path = write_package_to_temp_file(package)

--- a/tests/test_write_apkg.py
+++ b/tests/test_write_apkg.py
@@ -96,12 +96,17 @@ class TestWriteApkg(TestCase):
             "desc": "Test Description",
             "notes": [note]
         }
-        media_files = ['test.jpg', 'audio.mp3']
-        
+
         with tempfile.TemporaryDirectory() as tmpdir:
+            img_path = os.path.join(tmpdir, 'test.jpg')
+            audio_path = os.path.join(tmpdir, 'audio.mp3')
+            open(img_path, 'w').close()
+            open(audio_path, 'w').close()
+            media_files = [img_path, audio_path]
+
             with mock.patch('os.getcwd', return_value=tmpdir):
                 _write_new_apkg([deck_payload], media_files)
-                
+
                 mock_package.assert_called_once()
                 package_instance = mock_package.return_value
                 self.assertEqual(package_instance.media_files, media_files)
@@ -109,6 +114,28 @@ class TestWriteApkg(TestCase):
                 # Verify file operations
                 mock_package.return_value.write_to_file.assert_called_once()
                 mock_replace.assert_called_once()
+
+    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_skips_missing_media(self, mock_replace, mock_package):
+        note = Note(model=self.test_model, fields=['Q1', 'A1'])
+        deck_payload = {
+            "id": 1234567890,
+            "name": "Test Deck",
+            "desc": "Test Description",
+            "notes": [note]
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing_path = os.path.join(tmpdir, 'exists.jpg')
+            open(existing_path, 'w').close()
+            media_files = [existing_path, 'image.png']
+
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                _write_new_apkg([deck_payload], media_files)
+
+                package_instance = mock_package.return_value
+                self.assertEqual(package_instance.media_files, [existing_path])
 
     @mock.patch('helpers.write_apkg.Package')
     @mock.patch('helpers.write_apkg.os.replace')


### PR DESCRIPTION
Filter out non-existent media files before passing to genanki, so users still get their flashcards even if images are missing from the upload.